### PR TITLE
Improve PBKDF2 fallback performance

### DIFF
--- a/src/primitives/Hash.ts
+++ b/src/primitives/Hash.ts
@@ -1659,6 +1659,17 @@ export function pbkdf2 (
   } catch {
     // ignore
   }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fast = require('./fast/pbkdf2.js')
+    const sha = require('./fast/sha512.js')
+    const p = Uint8Array.from(password)
+    const s = Uint8Array.from(salt)
+    const out = fast.pbkdf2(sha.sha512, p, s, { c: iterations, dkLen: keylen })
+    return Array.from(out)
+  } catch {
+    // Fallback to original slow implementation if fast path fails
+  }
   const DK = new Array(keylen)
   const block1 = [...salt, 0, 0, 0, 0]
 

--- a/src/primitives/fast/_md.ts
+++ b/src/primitives/fast/_md.ts
@@ -1,0 +1,185 @@
+/**
+ * Internal Merkle-Damgard hash utils.
+ * @module
+ */
+import {
+  type Input,
+  Hash,
+  abytes,
+  aexists,
+  aoutput,
+  clean,
+  createView,
+  toBytes,
+} from './utils.js';
+
+/** Polyfill for Safari 14. https://caniuse.com/mdn-javascript_builtins_dataview_setbiguint64 */
+export function setBigUint64(
+  view: DataView,
+  byteOffset: number,
+  value: bigint,
+  isLE: boolean
+): void {
+  if (typeof view.setBigUint64 === 'function') return view.setBigUint64(byteOffset, value, isLE);
+  const _32n = BigInt(32);
+  const _u32_max = BigInt(0xffffffff);
+  const wh = Number((value >> _32n) & _u32_max);
+  const wl = Number(value & _u32_max);
+  const h = isLE ? 4 : 0;
+  const l = isLE ? 0 : 4;
+  view.setUint32(byteOffset + h, wh, isLE);
+  view.setUint32(byteOffset + l, wl, isLE);
+}
+
+/** Choice: a ? b : c */
+export function Chi(a: number, b: number, c: number): number {
+  return (a & b) ^ (~a & c);
+}
+
+/** Majority function, true if any two inputs is true. */
+export function Maj(a: number, b: number, c: number): number {
+  return (a & b) ^ (a & c) ^ (b & c);
+}
+
+/**
+ * Merkle-Damgard hash construction base class.
+ * Could be used to create MD5, RIPEMD, SHA1, SHA2.
+ */
+export abstract class HashMD<T extends HashMD<T>> extends Hash<T> {
+  protected abstract process(buf: DataView, offset: number): void;
+  protected abstract get(): number[];
+  protected abstract set(...args: number[]): void;
+  abstract destroy(): void;
+  protected abstract roundClean(): void;
+
+  readonly blockLen: number;
+  readonly outputLen: number;
+  readonly padOffset: number;
+  readonly isLE: boolean;
+
+  // For partial updates less than block size
+  protected buffer: Uint8Array;
+  protected view: DataView;
+  protected finished = false;
+  protected length = 0;
+  protected pos = 0;
+  protected destroyed = false;
+
+  constructor(blockLen: number, outputLen: number, padOffset: number, isLE: boolean) {
+    super();
+    this.blockLen = blockLen;
+    this.outputLen = outputLen;
+    this.padOffset = padOffset;
+    this.isLE = isLE;
+    this.buffer = new Uint8Array(blockLen);
+    this.view = createView(this.buffer);
+  }
+  update(data: Input): this {
+    aexists(this);
+    data = toBytes(data);
+    abytes(data);
+    const { view, buffer, blockLen } = this;
+    const len = data.length;
+    for (let pos = 0; pos < len; ) {
+      const take = Math.min(blockLen - this.pos, len - pos);
+      // Fast path: we have at least one block in input, cast it to view and process
+      if (take === blockLen) {
+        const dataView = createView(data);
+        for (; blockLen <= len - pos; pos += blockLen) this.process(dataView, pos);
+        continue;
+      }
+      buffer.set(data.subarray(pos, pos + take), this.pos);
+      this.pos += take;
+      pos += take;
+      if (this.pos === blockLen) {
+        this.process(view, 0);
+        this.pos = 0;
+      }
+    }
+    this.length += data.length;
+    this.roundClean();
+    return this;
+  }
+  digestInto(out: Uint8Array): void {
+    aexists(this);
+    aoutput(out, this);
+    this.finished = true;
+    // Padding
+    // We can avoid allocation of buffer for padding completely if it
+    // was previously not allocated here. But it won't change performance.
+    const { buffer, view, blockLen, isLE } = this;
+    let { pos } = this;
+    // append the bit '1' to the message
+    buffer[pos++] = 0b10000000;
+    clean(this.buffer.subarray(pos));
+    // we have less than padOffset left in buffer, so we cannot put length in
+    // current block, need process it and pad again
+    if (this.padOffset > blockLen - pos) {
+      this.process(view, 0);
+      pos = 0;
+    }
+    // Pad until full block byte with zeros
+    for (let i = pos; i < blockLen; i++) buffer[i] = 0;
+    // Note: sha512 requires length to be 128bit integer, but length in JS will overflow before that
+    // You need to write around 2 exabytes (u64_max / 8 / (1024**6)) for this to happen.
+    // So we just write lowest 64 bits of that value.
+    setBigUint64(view, blockLen - 8, BigInt(this.length * 8), isLE);
+    this.process(view, 0);
+    const oview = createView(out);
+    const len = this.outputLen;
+    // NOTE: we do division by 4 later, which should be fused in single op with modulo by JIT
+    if (len % 4) throw new Error('_sha2: outputLen should be aligned to 32bit');
+    const outLen = len / 4;
+    const state = this.get();
+    if (outLen > state.length) throw new Error('_sha2: outputLen bigger than state');
+    for (let i = 0; i < outLen; i++) oview.setUint32(4 * i, state[i], isLE);
+  }
+  digest(): Uint8Array {
+    const { buffer, outputLen } = this;
+    this.digestInto(buffer);
+    const res = buffer.slice(0, outputLen);
+    this.destroy();
+    return res;
+  }
+  _cloneInto(to?: T): T {
+    to ||= new (this.constructor as any)() as T;
+    to.set(...this.get());
+    const { blockLen, buffer, length, finished, destroyed, pos } = this;
+    to.destroyed = destroyed;
+    to.finished = finished;
+    to.length = length;
+    to.pos = pos;
+    if (length % blockLen) to.buffer.set(buffer);
+    return to;
+  }
+  clone(): T {
+    return this._cloneInto();
+  }
+}
+
+/**
+ * Initial SHA-2 state: fractional parts of square roots of first 16 primes 2..53.
+ * Check out `test/misc/sha2-gen-iv.js` for recomputation guide.
+ */
+
+/** Initial SHA256 state. Bits 0..32 of frac part of sqrt of primes 2..19 */
+export const SHA256_IV: Uint32Array = /* @__PURE__ */ Uint32Array.from([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+]);
+
+/** Initial SHA224 state. Bits 32..64 of frac part of sqrt of primes 23..53 */
+export const SHA224_IV: Uint32Array = /* @__PURE__ */ Uint32Array.from([
+  0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939, 0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4,
+]);
+
+/** Initial SHA384 state. Bits 0..64 of frac part of sqrt of primes 23..53 */
+export const SHA384_IV: Uint32Array = /* @__PURE__ */ Uint32Array.from([
+  0xcbbb9d5d, 0xc1059ed8, 0x629a292a, 0x367cd507, 0x9159015a, 0x3070dd17, 0x152fecd8, 0xf70e5939,
+  0x67332667, 0xffc00b31, 0x8eb44a87, 0x68581511, 0xdb0c2e0d, 0x64f98fa7, 0x47b5481d, 0xbefa4fa4,
+]);
+
+/** Initial SHA512 state. Bits 0..64 of frac part of sqrt of primes 2..19 */
+export const SHA512_IV: Uint32Array = /* @__PURE__ */ Uint32Array.from([
+  0x6a09e667, 0xf3bcc908, 0xbb67ae85, 0x84caa73b, 0x3c6ef372, 0xfe94f82b, 0xa54ff53a, 0x5f1d36f1,
+  0x510e527f, 0xade682d1, 0x9b05688c, 0x2b3e6c1f, 0x1f83d9ab, 0xfb41bd6b, 0x5be0cd19, 0x137e2179,
+]);

--- a/src/primitives/fast/_u64.ts
+++ b/src/primitives/fast/_u64.ts
@@ -1,0 +1,91 @@
+/**
+ * Internal helpers for u64. BigUint64Array is too slow as per 2025, so we implement it using Uint32Array.
+ * @todo re-check https://issues.chromium.org/issues/42212588
+ * @module
+ */
+const U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
+const _32n = /* @__PURE__ */ BigInt(32);
+
+function fromBig(
+  n: bigint,
+  le = false
+): {
+  h: number;
+  l: number;
+} {
+  if (le) return { h: Number(n & U32_MASK64), l: Number((n >> _32n) & U32_MASK64) };
+  return { h: Number((n >> _32n) & U32_MASK64) | 0, l: Number(n & U32_MASK64) | 0 };
+}
+
+function split(lst: bigint[], le = false): Uint32Array[] {
+  const len = lst.length;
+  let Ah = new Uint32Array(len);
+  let Al = new Uint32Array(len);
+  for (let i = 0; i < len; i++) {
+    const { h, l } = fromBig(lst[i], le);
+    [Ah[i], Al[i]] = [h, l];
+  }
+  return [Ah, Al];
+}
+
+const toBig = (h: number, l: number): bigint => (BigInt(h >>> 0) << _32n) | BigInt(l >>> 0);
+// for Shift in [0, 32)
+const shrSH = (h: number, _l: number, s: number): number => h >>> s;
+const shrSL = (h: number, l: number, s: number): number => (h << (32 - s)) | (l >>> s);
+// Right rotate for Shift in [1, 32)
+const rotrSH = (h: number, l: number, s: number): number => (h >>> s) | (l << (32 - s));
+const rotrSL = (h: number, l: number, s: number): number => (h << (32 - s)) | (l >>> s);
+// Right rotate for Shift in (32, 64), NOTE: 32 is special case.
+const rotrBH = (h: number, l: number, s: number): number => (h << (64 - s)) | (l >>> (s - 32));
+const rotrBL = (h: number, l: number, s: number): number => (h >>> (s - 32)) | (l << (64 - s));
+// Right rotate for shift===32 (just swaps l&h)
+const rotr32H = (_h: number, l: number): number => l;
+const rotr32L = (h: number, _l: number): number => h;
+// Left rotate for Shift in [1, 32)
+const rotlSH = (h: number, l: number, s: number): number => (h << s) | (l >>> (32 - s));
+const rotlSL = (h: number, l: number, s: number): number => (l << s) | (h >>> (32 - s));
+// Left rotate for Shift in (32, 64), NOTE: 32 is special case.
+const rotlBH = (h: number, l: number, s: number): number => (l << (s - 32)) | (h >>> (64 - s));
+const rotlBL = (h: number, l: number, s: number): number => (h << (s - 32)) | (l >>> (64 - s));
+
+// JS uses 32-bit signed integers for bitwise operations which means we cannot
+// simple take carry out of low bit sum by shift, we need to use division.
+function add(
+  Ah: number,
+  Al: number,
+  Bh: number,
+  Bl: number
+): {
+  h: number;
+  l: number;
+} {
+  const l = (Al >>> 0) + (Bl >>> 0);
+  return { h: (Ah + Bh + ((l / 2 ** 32) | 0)) | 0, l: l | 0 };
+}
+// Addition with more than 2 elements
+const add3L = (Al: number, Bl: number, Cl: number): number => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0);
+const add3H = (low: number, Ah: number, Bh: number, Ch: number): number =>
+  (Ah + Bh + Ch + ((low / 2 ** 32) | 0)) | 0;
+const add4L = (Al: number, Bl: number, Cl: number, Dl: number): number =>
+  (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0);
+const add4H = (low: number, Ah: number, Bh: number, Ch: number, Dh: number): number =>
+  (Ah + Bh + Ch + Dh + ((low / 2 ** 32) | 0)) | 0;
+const add5L = (Al: number, Bl: number, Cl: number, Dl: number, El: number): number =>
+  (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0) + (El >>> 0);
+const add5H = (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: number): number =>
+  (Ah + Bh + Ch + Dh + Eh + ((low / 2 ** 32) | 0)) | 0;
+
+// prettier-ignore
+export {
+  add, add3H, add3L, add4H, add4L, add5H, add5L, fromBig, rotlBH, rotlBL, rotlSH, rotlSL, rotr32H, rotr32L, rotrBH, rotrBL, rotrSH, rotrSL, shrSH, shrSL, split, toBig
+};
+// prettier-ignore
+const u64: { fromBig: typeof fromBig; split: typeof split; toBig: (h: number, l: number) => bigint; shrSH: (h: number, _l: number, s: number) => number; shrSL: (h: number, l: number, s: number) => number; rotrSH: (h: number, l: number, s: number) => number; rotrSL: (h: number, l: number, s: number) => number; rotrBH: (h: number, l: number, s: number) => number; rotrBL: (h: number, l: number, s: number) => number; rotr32H: (_h: number, l: number) => number; rotr32L: (h: number, _l: number) => number; rotlSH: (h: number, l: number, s: number) => number; rotlSL: (h: number, l: number, s: number) => number; rotlBH: (h: number, l: number, s: number) => number; rotlBL: (h: number, l: number, s: number) => number; add: typeof add; add3L: (Al: number, Bl: number, Cl: number) => number; add3H: (low: number, Ah: number, Bh: number, Ch: number) => number; add4L: (Al: number, Bl: number, Cl: number, Dl: number) => number; add4H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number) => number; add5H: (low: number, Ah: number, Bh: number, Ch: number, Dh: number, Eh: number) => number; add5L: (Al: number, Bl: number, Cl: number, Dl: number, El: number) => number; } = {
+  fromBig, split, toBig,
+  shrSH, shrSL,
+  rotrSH, rotrSL, rotrBH, rotrBL,
+  rotr32H, rotr32L,
+  rotlSH, rotlSL, rotlBH, rotlBL,
+  add, add3L, add3H, add4L, add4H, add5H, add5L,
+};
+export default u64;

--- a/src/primitives/fast/hmac.ts
+++ b/src/primitives/fast/hmac.ts
@@ -1,0 +1,103 @@
+/**
+ * HMAC: RFC2104 message authentication code.
+ * @module
+ */
+import {
+  abytes,
+  aexists,
+  ahash,
+  clean,
+  Hash,
+  toBytes,
+  type CHash,
+  type Input,
+} from './utils.js';
+
+export class HMAC<T extends Hash<T>> extends Hash<HMAC<T>> {
+  oHash: T;
+  iHash: T;
+  blockLen: number;
+  outputLen: number;
+  private finished = false;
+  private destroyed = false;
+
+  constructor(hash: CHash, _key: Input) {
+    super();
+    ahash(hash);
+    const key = toBytes(_key);
+    this.iHash = hash.create() as T;
+    if (typeof this.iHash.update !== 'function')
+      throw new Error('Expected instance of class which extends utils.Hash');
+    this.blockLen = this.iHash.blockLen;
+    this.outputLen = this.iHash.outputLen;
+    const blockLen = this.blockLen;
+    const pad = new Uint8Array(blockLen);
+    // blockLen can be bigger than outputLen
+    pad.set(key.length > blockLen ? hash.create().update(key).digest() : key);
+    for (let i = 0; i < pad.length; i++) pad[i] ^= 0x36;
+    this.iHash.update(pad);
+    // By doing update (processing of first block) of outer hash here we can re-use it between multiple calls via clone
+    this.oHash = hash.create() as T;
+    // Undo internal XOR && apply outer XOR
+    for (let i = 0; i < pad.length; i++) pad[i] ^= 0x36 ^ 0x5c;
+    this.oHash.update(pad);
+    clean(pad);
+  }
+  update(buf: Input): this {
+    aexists(this);
+    this.iHash.update(buf);
+    return this;
+  }
+  digestInto(out: Uint8Array): void {
+    aexists(this);
+    abytes(out, this.outputLen);
+    this.finished = true;
+    this.iHash.digestInto(out);
+    this.oHash.update(out);
+    this.oHash.digestInto(out);
+    this.destroy();
+  }
+  digest(): Uint8Array {
+    const out = new Uint8Array(this.oHash.outputLen);
+    this.digestInto(out);
+    return out;
+  }
+  _cloneInto(to?: HMAC<T>): HMAC<T> {
+    // Create new instance without calling constructor since key already in state and we don't know it.
+    to ||= Object.create(Object.getPrototypeOf(this), {});
+    const { oHash, iHash, finished, destroyed, blockLen, outputLen } = this;
+    to = to as this;
+    to.finished = finished;
+    to.destroyed = destroyed;
+    to.blockLen = blockLen;
+    to.outputLen = outputLen;
+    to.oHash = oHash._cloneInto(to.oHash);
+    to.iHash = iHash._cloneInto(to.iHash);
+    return to;
+  }
+  clone(): HMAC<T> {
+    return this._cloneInto();
+  }
+  destroy(): void {
+    this.destroyed = true;
+    this.oHash.destroy();
+    this.iHash.destroy();
+  }
+}
+
+/**
+ * HMAC: RFC2104 message authentication code.
+ * @param hash - function that would be used e.g. sha256
+ * @param key - message key
+ * @param message - message data
+ * @example
+ * import { hmac } from '@noble/hashes/hmac';
+ * import { sha256 } from '@noble/hashes/sha2';
+ * const mac1 = hmac(sha256, 'key', 'message');
+ */
+export const hmac: {
+  (hash: CHash, key: Input, message: Input): Uint8Array;
+  create(hash: CHash, key: Input): HMAC<any>;
+} = (hash: CHash, key: Input, message: Input): Uint8Array =>
+  new HMAC<any>(hash, key).update(message).digest();
+hmac.create = (hash: CHash, key: Input) => new HMAC<any>(hash, key);

--- a/src/primitives/fast/pbkdf2.ts
+++ b/src/primitives/fast/pbkdf2.ts
@@ -1,0 +1,128 @@
+/**
+ * PBKDF (RFC 2898). Can be used to create a key from password and salt.
+ * @module
+ */
+import { hmac } from './hmac.js';
+// prettier-ignore
+import {
+  ahash,
+  anumber,
+  asyncLoop,
+  checkOpts,
+  clean,
+  createView,
+  Hash,
+  kdfInputToBytes,
+  type CHash,
+  type KDFInput,
+} from './utils.js';
+
+export type Pbkdf2Opt = {
+  c: number; // Iterations
+  dkLen?: number; // Desired key length in bytes (Intended output length in octets of the derived key
+  asyncTick?: number; // Maximum time in ms for which async function can block execution
+};
+// Common prologue and epilogue for sync/async functions
+function pbkdf2Init(hash: CHash, _password: KDFInput, _salt: KDFInput, _opts: Pbkdf2Opt) {
+  ahash(hash);
+  const opts = checkOpts({ dkLen: 32, asyncTick: 10 }, _opts);
+  const { c, dkLen, asyncTick } = opts;
+  anumber(c);
+  anumber(dkLen);
+  anumber(asyncTick);
+  if (c < 1) throw new Error('iterations (c) should be >= 1');
+  const password = kdfInputToBytes(_password);
+  const salt = kdfInputToBytes(_salt);
+  // DK = PBKDF2(PRF, Password, Salt, c, dkLen);
+  const DK = new Uint8Array(dkLen);
+  // U1 = PRF(Password, Salt + INT_32_BE(i))
+  const PRF = hmac.create(hash, password);
+  const PRFSalt = PRF._cloneInto().update(salt);
+  return { c, dkLen, asyncTick, DK, PRF, PRFSalt };
+}
+
+function pbkdf2Output<T extends Hash<T>>(
+  PRF: Hash<T>,
+  PRFSalt: Hash<T>,
+  DK: Uint8Array,
+  prfW: Hash<T>,
+  u: Uint8Array
+) {
+  PRF.destroy();
+  PRFSalt.destroy();
+  if (prfW) prfW.destroy();
+  clean(u);
+  return DK;
+}
+
+/**
+ * PBKDF2-HMAC: RFC 2898 key derivation function
+ * @param hash - hash function that would be used e.g. sha256
+ * @param password - password from which a derived key is generated
+ * @param salt - cryptographic salt
+ * @param opts - {c, dkLen} where c is work factor and dkLen is output message size
+ * @example
+ * const key = pbkdf2(sha256, 'password', 'salt', { dkLen: 32, c: Math.pow(2, 18) });
+ */
+export function pbkdf2(
+  hash: CHash,
+  password: KDFInput,
+  salt: KDFInput,
+  opts: Pbkdf2Opt
+): Uint8Array {
+  const { c, dkLen, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
+  let prfW: any; // Working copy
+  const arr = new Uint8Array(4);
+  const view = createView(arr);
+  const u = new Uint8Array(PRF.outputLen);
+  // DK = T1 + T2 + ⋯ + Tdklen/hlen
+  for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
+    // Ti = F(Password, Salt, c, i)
+    const Ti = DK.subarray(pos, pos + PRF.outputLen);
+    view.setInt32(0, ti, false);
+    // F(Password, Salt, c, i) = U1 ^ U2 ^ ⋯ ^ Uc
+    // U1 = PRF(Password, Salt + INT_32_BE(i))
+    (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
+    Ti.set(u.subarray(0, Ti.length));
+    for (let ui = 1; ui < c; ui++) {
+      // Uc = PRF(Password, Uc−1)
+      PRF._cloneInto(prfW).update(u).digestInto(u);
+      for (let i = 0; i < Ti.length; i++) Ti[i] ^= u[i];
+    }
+  }
+  return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
+}
+
+/**
+ * PBKDF2-HMAC: RFC 2898 key derivation function. Async version.
+ * @example
+ * await pbkdf2Async(sha256, 'password', 'salt', { dkLen: 32, c: 500_000 });
+ */
+export async function pbkdf2Async(
+  hash: CHash,
+  password: KDFInput,
+  salt: KDFInput,
+  opts: Pbkdf2Opt
+): Promise<Uint8Array> {
+  const { c, dkLen, asyncTick, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
+  let prfW: any; // Working copy
+  const arr = new Uint8Array(4);
+  const view = createView(arr);
+  const u = new Uint8Array(PRF.outputLen);
+  // DK = T1 + T2 + ⋯ + Tdklen/hlen
+  for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
+    // Ti = F(Password, Salt, c, i)
+    const Ti = DK.subarray(pos, pos + PRF.outputLen);
+    view.setInt32(0, ti, false);
+    // F(Password, Salt, c, i) = U1 ^ U2 ^ ⋯ ^ Uc
+    // U1 = PRF(Password, Salt + INT_32_BE(i))
+    (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
+    Ti.set(u.subarray(0, Ti.length));
+    await asyncLoop(c - 1, asyncTick, () => {
+      // Uc = PRF(Password, Uc−1)
+      PRF._cloneInto(prfW).update(u).digestInto(u);
+      for (let i = 0; i < Ti.length; i++) Ti[i] ^= u[i];
+    });
+  }
+  return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
+}

--- a/src/primitives/fast/sha2.ts
+++ b/src/primitives/fast/sha2.ts
@@ -1,0 +1,402 @@
+/**
+ * SHA2 hash function. A.k.a. sha256, sha384, sha512, sha512_224, sha512_256.
+ * SHA256 is the fastest hash implementable in JS, even faster than Blake3.
+ * Check out [RFC 4634](https://datatracker.ietf.org/doc/html/rfc4634) and
+ * [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf).
+ * @module
+ */
+import { Chi, HashMD, Maj, SHA224_IV, SHA256_IV, SHA384_IV, SHA512_IV } from './_md.js';
+import * as u64 from './_u64.js';
+import { type CHash, clean, createHasher, rotr } from './utils.js';
+
+/**
+ * Round constants:
+ * First 32 bits of fractional parts of the cube roots of the first 64 primes 2..311)
+ */
+// prettier-ignore
+const SHA256_K = /* @__PURE__ */ Uint32Array.from([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+]);
+
+/** Reusable temporary buffer. "W" comes straight from spec. */
+const SHA256_W = /* @__PURE__ */ new Uint32Array(64);
+export class SHA256 extends HashMD<SHA256> {
+  // We cannot use array here since array allows indexing by variable
+  // which means optimizer/compiler cannot use registers.
+  protected A: number = SHA256_IV[0] | 0;
+  protected B: number = SHA256_IV[1] | 0;
+  protected C: number = SHA256_IV[2] | 0;
+  protected D: number = SHA256_IV[3] | 0;
+  protected E: number = SHA256_IV[4] | 0;
+  protected F: number = SHA256_IV[5] | 0;
+  protected G: number = SHA256_IV[6] | 0;
+  protected H: number = SHA256_IV[7] | 0;
+
+  constructor(outputLen: number = 32) {
+    super(64, outputLen, 8, false);
+  }
+  protected get(): [number, number, number, number, number, number, number, number] {
+    const { A, B, C, D, E, F, G, H } = this;
+    return [A, B, C, D, E, F, G, H];
+  }
+  // prettier-ignore
+  protected set(
+    A: number, B: number, C: number, D: number, E: number, F: number, G: number, H: number
+  ): void {
+    this.A = A | 0;
+    this.B = B | 0;
+    this.C = C | 0;
+    this.D = D | 0;
+    this.E = E | 0;
+    this.F = F | 0;
+    this.G = G | 0;
+    this.H = H | 0;
+  }
+  protected process(view: DataView, offset: number): void {
+    // Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array
+    for (let i = 0; i < 16; i++, offset += 4) SHA256_W[i] = view.getUint32(offset, false);
+    for (let i = 16; i < 64; i++) {
+      const W15 = SHA256_W[i - 15];
+      const W2 = SHA256_W[i - 2];
+      const s0 = rotr(W15, 7) ^ rotr(W15, 18) ^ (W15 >>> 3);
+      const s1 = rotr(W2, 17) ^ rotr(W2, 19) ^ (W2 >>> 10);
+      SHA256_W[i] = (s1 + SHA256_W[i - 7] + s0 + SHA256_W[i - 16]) | 0;
+    }
+    // Compression function main loop, 64 rounds
+    let { A, B, C, D, E, F, G, H } = this;
+    for (let i = 0; i < 64; i++) {
+      const sigma1 = rotr(E, 6) ^ rotr(E, 11) ^ rotr(E, 25);
+      const T1 = (H + sigma1 + Chi(E, F, G) + SHA256_K[i] + SHA256_W[i]) | 0;
+      const sigma0 = rotr(A, 2) ^ rotr(A, 13) ^ rotr(A, 22);
+      const T2 = (sigma0 + Maj(A, B, C)) | 0;
+      H = G;
+      G = F;
+      F = E;
+      E = (D + T1) | 0;
+      D = C;
+      C = B;
+      B = A;
+      A = (T1 + T2) | 0;
+    }
+    // Add the compressed chunk to the current hash value
+    A = (A + this.A) | 0;
+    B = (B + this.B) | 0;
+    C = (C + this.C) | 0;
+    D = (D + this.D) | 0;
+    E = (E + this.E) | 0;
+    F = (F + this.F) | 0;
+    G = (G + this.G) | 0;
+    H = (H + this.H) | 0;
+    this.set(A, B, C, D, E, F, G, H);
+  }
+  protected roundClean(): void {
+    clean(SHA256_W);
+  }
+  destroy(): void {
+    this.set(0, 0, 0, 0, 0, 0, 0, 0);
+    clean(this.buffer);
+  }
+}
+
+export class SHA224 extends SHA256 {
+  protected A: number = SHA224_IV[0] | 0;
+  protected B: number = SHA224_IV[1] | 0;
+  protected C: number = SHA224_IV[2] | 0;
+  protected D: number = SHA224_IV[3] | 0;
+  protected E: number = SHA224_IV[4] | 0;
+  protected F: number = SHA224_IV[5] | 0;
+  protected G: number = SHA224_IV[6] | 0;
+  protected H: number = SHA224_IV[7] | 0;
+  constructor() {
+    super(28);
+  }
+}
+
+// SHA2-512 is slower than sha256 in js because u64 operations are slow.
+
+// Round contants
+// First 32 bits of the fractional parts of the cube roots of the first 80 primes 2..409
+// prettier-ignore
+const K512 = /* @__PURE__ */ (() => u64.split([
+  '0x428a2f98d728ae22', '0x7137449123ef65cd', '0xb5c0fbcfec4d3b2f', '0xe9b5dba58189dbbc',
+  '0x3956c25bf348b538', '0x59f111f1b605d019', '0x923f82a4af194f9b', '0xab1c5ed5da6d8118',
+  '0xd807aa98a3030242', '0x12835b0145706fbe', '0x243185be4ee4b28c', '0x550c7dc3d5ffb4e2',
+  '0x72be5d74f27b896f', '0x80deb1fe3b1696b1', '0x9bdc06a725c71235', '0xc19bf174cf692694',
+  '0xe49b69c19ef14ad2', '0xefbe4786384f25e3', '0x0fc19dc68b8cd5b5', '0x240ca1cc77ac9c65',
+  '0x2de92c6f592b0275', '0x4a7484aa6ea6e483', '0x5cb0a9dcbd41fbd4', '0x76f988da831153b5',
+  '0x983e5152ee66dfab', '0xa831c66d2db43210', '0xb00327c898fb213f', '0xbf597fc7beef0ee4',
+  '0xc6e00bf33da88fc2', '0xd5a79147930aa725', '0x06ca6351e003826f', '0x142929670a0e6e70',
+  '0x27b70a8546d22ffc', '0x2e1b21385c26c926', '0x4d2c6dfc5ac42aed', '0x53380d139d95b3df',
+  '0x650a73548baf63de', '0x766a0abb3c77b2a8', '0x81c2c92e47edaee6', '0x92722c851482353b',
+  '0xa2bfe8a14cf10364', '0xa81a664bbc423001', '0xc24b8b70d0f89791', '0xc76c51a30654be30',
+  '0xd192e819d6ef5218', '0xd69906245565a910', '0xf40e35855771202a', '0x106aa07032bbd1b8',
+  '0x19a4c116b8d2d0c8', '0x1e376c085141ab53', '0x2748774cdf8eeb99', '0x34b0bcb5e19b48a8',
+  '0x391c0cb3c5c95a63', '0x4ed8aa4ae3418acb', '0x5b9cca4f7763e373', '0x682e6ff3d6b2b8a3',
+  '0x748f82ee5defb2fc', '0x78a5636f43172f60', '0x84c87814a1f0ab72', '0x8cc702081a6439ec',
+  '0x90befffa23631e28', '0xa4506cebde82bde9', '0xbef9a3f7b2c67915', '0xc67178f2e372532b',
+  '0xca273eceea26619c', '0xd186b8c721c0c207', '0xeada7dd6cde0eb1e', '0xf57d4f7fee6ed178',
+  '0x06f067aa72176fba', '0x0a637dc5a2c898a6', '0x113f9804bef90dae', '0x1b710b35131c471b',
+  '0x28db77f523047d84', '0x32caab7b40c72493', '0x3c9ebe0a15c9bebc', '0x431d67c49c100d4c',
+  '0x4cc5d4becb3e42b6', '0x597f299cfc657e2a', '0x5fcb6fab3ad6faec', '0x6c44198c4a475817'
+].map(n => BigInt(n))))();
+const SHA512_Kh = /* @__PURE__ */ (() => K512[0])();
+const SHA512_Kl = /* @__PURE__ */ (() => K512[1])();
+
+// Reusable temporary buffers
+const SHA512_W_H = /* @__PURE__ */ new Uint32Array(80);
+const SHA512_W_L = /* @__PURE__ */ new Uint32Array(80);
+
+export class SHA512 extends HashMD<SHA512> {
+  // We cannot use array here since array allows indexing by variable
+  // which means optimizer/compiler cannot use registers.
+  // h -- high 32 bits, l -- low 32 bits
+  protected Ah: number = SHA512_IV[0] | 0;
+  protected Al: number = SHA512_IV[1] | 0;
+  protected Bh: number = SHA512_IV[2] | 0;
+  protected Bl: number = SHA512_IV[3] | 0;
+  protected Ch: number = SHA512_IV[4] | 0;
+  protected Cl: number = SHA512_IV[5] | 0;
+  protected Dh: number = SHA512_IV[6] | 0;
+  protected Dl: number = SHA512_IV[7] | 0;
+  protected Eh: number = SHA512_IV[8] | 0;
+  protected El: number = SHA512_IV[9] | 0;
+  protected Fh: number = SHA512_IV[10] | 0;
+  protected Fl: number = SHA512_IV[11] | 0;
+  protected Gh: number = SHA512_IV[12] | 0;
+  protected Gl: number = SHA512_IV[13] | 0;
+  protected Hh: number = SHA512_IV[14] | 0;
+  protected Hl: number = SHA512_IV[15] | 0;
+
+  constructor(outputLen: number = 64) {
+    super(128, outputLen, 16, false);
+  }
+  // prettier-ignore
+  protected get(): [
+    number, number, number, number, number, number, number, number,
+    number, number, number, number, number, number, number, number
+  ] {
+    const { Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl } = this;
+    return [Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl];
+  }
+  // prettier-ignore
+  protected set(
+    Ah: number, Al: number, Bh: number, Bl: number, Ch: number, Cl: number, Dh: number, Dl: number,
+    Eh: number, El: number, Fh: number, Fl: number, Gh: number, Gl: number, Hh: number, Hl: number
+  ): void {
+    this.Ah = Ah | 0;
+    this.Al = Al | 0;
+    this.Bh = Bh | 0;
+    this.Bl = Bl | 0;
+    this.Ch = Ch | 0;
+    this.Cl = Cl | 0;
+    this.Dh = Dh | 0;
+    this.Dl = Dl | 0;
+    this.Eh = Eh | 0;
+    this.El = El | 0;
+    this.Fh = Fh | 0;
+    this.Fl = Fl | 0;
+    this.Gh = Gh | 0;
+    this.Gl = Gl | 0;
+    this.Hh = Hh | 0;
+    this.Hl = Hl | 0;
+  }
+  protected process(view: DataView, offset: number): void {
+    // Extend the first 16 words into the remaining 64 words w[16..79] of the message schedule array
+    for (let i = 0; i < 16; i++, offset += 4) {
+      SHA512_W_H[i] = view.getUint32(offset);
+      SHA512_W_L[i] = view.getUint32((offset += 4));
+    }
+    for (let i = 16; i < 80; i++) {
+      // s0 := (w[i-15] rightrotate 1) xor (w[i-15] rightrotate 8) xor (w[i-15] rightshift 7)
+      const W15h = SHA512_W_H[i - 15] | 0;
+      const W15l = SHA512_W_L[i - 15] | 0;
+      const s0h = u64.rotrSH(W15h, W15l, 1) ^ u64.rotrSH(W15h, W15l, 8) ^ u64.shrSH(W15h, W15l, 7);
+      const s0l = u64.rotrSL(W15h, W15l, 1) ^ u64.rotrSL(W15h, W15l, 8) ^ u64.shrSL(W15h, W15l, 7);
+      // s1 := (w[i-2] rightrotate 19) xor (w[i-2] rightrotate 61) xor (w[i-2] rightshift 6)
+      const W2h = SHA512_W_H[i - 2] | 0;
+      const W2l = SHA512_W_L[i - 2] | 0;
+      const s1h = u64.rotrSH(W2h, W2l, 19) ^ u64.rotrBH(W2h, W2l, 61) ^ u64.shrSH(W2h, W2l, 6);
+      const s1l = u64.rotrSL(W2h, W2l, 19) ^ u64.rotrBL(W2h, W2l, 61) ^ u64.shrSL(W2h, W2l, 6);
+      // SHA256_W[i] = s0 + s1 + SHA256_W[i - 7] + SHA256_W[i - 16];
+      const SUMl = u64.add4L(s0l, s1l, SHA512_W_L[i - 7], SHA512_W_L[i - 16]);
+      const SUMh = u64.add4H(SUMl, s0h, s1h, SHA512_W_H[i - 7], SHA512_W_H[i - 16]);
+      SHA512_W_H[i] = SUMh | 0;
+      SHA512_W_L[i] = SUMl | 0;
+    }
+    let { Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl } = this;
+    // Compression function main loop, 80 rounds
+    for (let i = 0; i < 80; i++) {
+      // S1 := (e rightrotate 14) xor (e rightrotate 18) xor (e rightrotate 41)
+      const sigma1h = u64.rotrSH(Eh, El, 14) ^ u64.rotrSH(Eh, El, 18) ^ u64.rotrBH(Eh, El, 41);
+      const sigma1l = u64.rotrSL(Eh, El, 14) ^ u64.rotrSL(Eh, El, 18) ^ u64.rotrBL(Eh, El, 41);
+      //const T1 = (H + sigma1 + Chi(E, F, G) + SHA256_K[i] + SHA256_W[i]) | 0;
+      const CHIh = (Eh & Fh) ^ (~Eh & Gh);
+      const CHIl = (El & Fl) ^ (~El & Gl);
+      // T1 = H + sigma1 + Chi(E, F, G) + SHA512_K[i] + SHA512_W[i]
+      // prettier-ignore
+      const T1ll = u64.add5L(Hl, sigma1l, CHIl, SHA512_Kl[i], SHA512_W_L[i]);
+      const T1h = u64.add5H(T1ll, Hh, sigma1h, CHIh, SHA512_Kh[i], SHA512_W_H[i]);
+      const T1l = T1ll | 0;
+      // S0 := (a rightrotate 28) xor (a rightrotate 34) xor (a rightrotate 39)
+      const sigma0h = u64.rotrSH(Ah, Al, 28) ^ u64.rotrBH(Ah, Al, 34) ^ u64.rotrBH(Ah, Al, 39);
+      const sigma0l = u64.rotrSL(Ah, Al, 28) ^ u64.rotrBL(Ah, Al, 34) ^ u64.rotrBL(Ah, Al, 39);
+      const MAJh = (Ah & Bh) ^ (Ah & Ch) ^ (Bh & Ch);
+      const MAJl = (Al & Bl) ^ (Al & Cl) ^ (Bl & Cl);
+      Hh = Gh | 0;
+      Hl = Gl | 0;
+      Gh = Fh | 0;
+      Gl = Fl | 0;
+      Fh = Eh | 0;
+      Fl = El | 0;
+      ({ h: Eh, l: El } = u64.add(Dh | 0, Dl | 0, T1h | 0, T1l | 0));
+      Dh = Ch | 0;
+      Dl = Cl | 0;
+      Ch = Bh | 0;
+      Cl = Bl | 0;
+      Bh = Ah | 0;
+      Bl = Al | 0;
+      const All = u64.add3L(T1l, sigma0l, MAJl);
+      Ah = u64.add3H(All, T1h, sigma0h, MAJh);
+      Al = All | 0;
+    }
+    // Add the compressed chunk to the current hash value
+    ({ h: Ah, l: Al } = u64.add(this.Ah | 0, this.Al | 0, Ah | 0, Al | 0));
+    ({ h: Bh, l: Bl } = u64.add(this.Bh | 0, this.Bl | 0, Bh | 0, Bl | 0));
+    ({ h: Ch, l: Cl } = u64.add(this.Ch | 0, this.Cl | 0, Ch | 0, Cl | 0));
+    ({ h: Dh, l: Dl } = u64.add(this.Dh | 0, this.Dl | 0, Dh | 0, Dl | 0));
+    ({ h: Eh, l: El } = u64.add(this.Eh | 0, this.El | 0, Eh | 0, El | 0));
+    ({ h: Fh, l: Fl } = u64.add(this.Fh | 0, this.Fl | 0, Fh | 0, Fl | 0));
+    ({ h: Gh, l: Gl } = u64.add(this.Gh | 0, this.Gl | 0, Gh | 0, Gl | 0));
+    ({ h: Hh, l: Hl } = u64.add(this.Hh | 0, this.Hl | 0, Hh | 0, Hl | 0));
+    this.set(Ah, Al, Bh, Bl, Ch, Cl, Dh, Dl, Eh, El, Fh, Fl, Gh, Gl, Hh, Hl);
+  }
+  protected roundClean(): void {
+    clean(SHA512_W_H, SHA512_W_L);
+  }
+  destroy(): void {
+    clean(this.buffer);
+    this.set(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  }
+}
+
+export class SHA384 extends SHA512 {
+  protected Ah: number = SHA384_IV[0] | 0;
+  protected Al: number = SHA384_IV[1] | 0;
+  protected Bh: number = SHA384_IV[2] | 0;
+  protected Bl: number = SHA384_IV[3] | 0;
+  protected Ch: number = SHA384_IV[4] | 0;
+  protected Cl: number = SHA384_IV[5] | 0;
+  protected Dh: number = SHA384_IV[6] | 0;
+  protected Dl: number = SHA384_IV[7] | 0;
+  protected Eh: number = SHA384_IV[8] | 0;
+  protected El: number = SHA384_IV[9] | 0;
+  protected Fh: number = SHA384_IV[10] | 0;
+  protected Fl: number = SHA384_IV[11] | 0;
+  protected Gh: number = SHA384_IV[12] | 0;
+  protected Gl: number = SHA384_IV[13] | 0;
+  protected Hh: number = SHA384_IV[14] | 0;
+  protected Hl: number = SHA384_IV[15] | 0;
+
+  constructor() {
+    super(48);
+  }
+}
+
+/**
+ * Truncated SHA512/256 and SHA512/224.
+ * SHA512_IV is XORed with 0xa5a5a5a5a5a5a5a5, then used as "intermediary" IV of SHA512/t.
+ * Then t hashes string to produce result IV.
+ * See `test/misc/sha2-gen-iv.js`.
+ */
+
+/** SHA512/224 IV */
+const T224_IV = /* @__PURE__ */ Uint32Array.from([
+  0x8c3d37c8, 0x19544da2, 0x73e19966, 0x89dcd4d6, 0x1dfab7ae, 0x32ff9c82, 0x679dd514, 0x582f9fcf,
+  0x0f6d2b69, 0x7bd44da8, 0x77e36f73, 0x04c48942, 0x3f9d85a8, 0x6a1d36c8, 0x1112e6ad, 0x91d692a1,
+]);
+
+/** SHA512/256 IV */
+const T256_IV = /* @__PURE__ */ Uint32Array.from([
+  0x22312194, 0xfc2bf72c, 0x9f555fa3, 0xc84c64c2, 0x2393b86b, 0x6f53b151, 0x96387719, 0x5940eabd,
+  0x96283ee2, 0xa88effe3, 0xbe5e1e25, 0x53863992, 0x2b0199fc, 0x2c85b8aa, 0x0eb72ddc, 0x81c52ca2,
+]);
+
+export class SHA512_224 extends SHA512 {
+  protected Ah: number = T224_IV[0] | 0;
+  protected Al: number = T224_IV[1] | 0;
+  protected Bh: number = T224_IV[2] | 0;
+  protected Bl: number = T224_IV[3] | 0;
+  protected Ch: number = T224_IV[4] | 0;
+  protected Cl: number = T224_IV[5] | 0;
+  protected Dh: number = T224_IV[6] | 0;
+  protected Dl: number = T224_IV[7] | 0;
+  protected Eh: number = T224_IV[8] | 0;
+  protected El: number = T224_IV[9] | 0;
+  protected Fh: number = T224_IV[10] | 0;
+  protected Fl: number = T224_IV[11] | 0;
+  protected Gh: number = T224_IV[12] | 0;
+  protected Gl: number = T224_IV[13] | 0;
+  protected Hh: number = T224_IV[14] | 0;
+  protected Hl: number = T224_IV[15] | 0;
+
+  constructor() {
+    super(28);
+  }
+}
+
+export class SHA512_256 extends SHA512 {
+  protected Ah: number = T256_IV[0] | 0;
+  protected Al: number = T256_IV[1] | 0;
+  protected Bh: number = T256_IV[2] | 0;
+  protected Bl: number = T256_IV[3] | 0;
+  protected Ch: number = T256_IV[4] | 0;
+  protected Cl: number = T256_IV[5] | 0;
+  protected Dh: number = T256_IV[6] | 0;
+  protected Dl: number = T256_IV[7] | 0;
+  protected Eh: number = T256_IV[8] | 0;
+  protected El: number = T256_IV[9] | 0;
+  protected Fh: number = T256_IV[10] | 0;
+  protected Fl: number = T256_IV[11] | 0;
+  protected Gh: number = T256_IV[12] | 0;
+  protected Gl: number = T256_IV[13] | 0;
+  protected Hh: number = T256_IV[14] | 0;
+  protected Hl: number = T256_IV[15] | 0;
+
+  constructor() {
+    super(32);
+  }
+}
+
+/**
+ * SHA2-256 hash function from RFC 4634.
+ *
+ * It is the fastest JS hash, even faster than Blake3.
+ * To break sha256 using birthday attack, attackers need to try 2^128 hashes.
+ * BTC network is doing 2^70 hashes/sec (2^95 hashes/year) as per 2025.
+ */
+export const sha256: CHash = /* @__PURE__ */ createHasher(() => new SHA256());
+/** SHA2-224 hash function from RFC 4634 */
+export const sha224: CHash = /* @__PURE__ */ createHasher(() => new SHA224());
+
+/** SHA2-512 hash function from RFC 4634. */
+export const sha512: CHash = /* @__PURE__ */ createHasher(() => new SHA512());
+/** SHA2-384 hash function from RFC 4634. */
+export const sha384: CHash = /* @__PURE__ */ createHasher(() => new SHA384());
+
+/**
+ * SHA2-512/256 "truncated" hash function, with improved resistance to length extension attacks.
+ * See the paper on [truncated SHA512](https://eprint.iacr.org/2010/548.pdf).
+ */
+export const sha512_256: CHash = /* @__PURE__ */ createHasher(() => new SHA512_256());
+/**
+ * SHA2-512/224 "truncated" hash function, with improved resistance to length extension attacks.
+ * See the paper on [truncated SHA512](https://eprint.iacr.org/2010/548.pdf).
+ */
+export const sha512_224: CHash = /* @__PURE__ */ createHasher(() => new SHA512_224());

--- a/src/primitives/fast/sha512.ts
+++ b/src/primitives/fast/sha512.ts
@@ -1,0 +1,34 @@
+/**
+ * SHA2-512 a.k.a. sha512 and sha384. It is slower than sha256 in js because u64 operations are slow.
+ *
+ * Check out [RFC 4634](https://datatracker.ietf.org/doc/html/rfc4634) and
+ * [the paper on truncated SHA512/256](https://eprint.iacr.org/2010/548.pdf).
+ * @module
+ * @deprecated
+ */
+import {
+  SHA384 as SHA384n,
+  sha384 as sha384n,
+  sha512_224 as sha512_224n,
+  SHA512_224 as SHA512_224n,
+  sha512_256 as sha512_256n,
+  SHA512_256 as SHA512_256n,
+  SHA512 as SHA512n,
+  sha512 as sha512n,
+} from './sha2.js';
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const SHA512: typeof SHA512n = SHA512n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const sha512: typeof sha512n = sha512n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const SHA384: typeof SHA384n = SHA384n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const sha384: typeof sha384n = sha384n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const SHA512_224: typeof SHA512_224n = SHA512_224n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const sha512_224: typeof sha512_224n = sha512_224n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const SHA512_256: typeof SHA512_256n = SHA512_256n;
+/** @deprecated Use import from `noble/hashes/sha2` module */
+export const sha512_256: typeof sha512_256n = sha512_256n;

--- a/src/primitives/fast/utils.ts
+++ b/src/primitives/fast/utils.ts
@@ -1,0 +1,390 @@
+/**
+ * Utilities for hex, bytes, CSPRNG.
+ * @module
+ */
+/*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) */
+
+// We use WebCrypto aka globalThis.crypto, which exists in browsers and node.js 16+.
+// node.js versions earlier than v19 don't declare it in global scope.
+// For node.js, package.json#exports field mapping rewrites import
+// from `crypto` to `cryptoNode`, which imports native module.
+// Makes the utils un-importable in browsers without a bundler.
+// Once node.js 18 is deprecated (2025-04-30), we can just drop the import.
+
+/** Checks if something is Uint8Array. Be careful: nodejs Buffer will return true. */
+export function isBytes(a: unknown): a is Uint8Array {
+  return a instanceof Uint8Array || (ArrayBuffer.isView(a) && a.constructor.name === 'Uint8Array');
+}
+
+/** Asserts something is positive integer. */
+export function anumber(n: number): void {
+  if (!Number.isSafeInteger(n) || n < 0) throw new Error('positive integer expected, got ' + n);
+}
+
+/** Asserts something is Uint8Array. */
+export function abytes(b: Uint8Array | undefined, ...lengths: number[]): void {
+  if (!isBytes(b)) throw new Error('Uint8Array expected');
+  if (lengths.length > 0 && !lengths.includes(b.length))
+    throw new Error('Uint8Array expected of length ' + lengths + ', got length=' + b.length);
+}
+
+/** Asserts something is hash */
+export function ahash(h: IHash): void {
+  if (typeof h !== 'function' || typeof h.create !== 'function')
+    throw new Error('Hash should be wrapped by utils.createHasher');
+  anumber(h.outputLen);
+  anumber(h.blockLen);
+}
+
+/** Asserts a hash instance has not been destroyed / finished */
+export function aexists(instance: any, checkFinished = true): void {
+  if (instance.destroyed) throw new Error('Hash instance has been destroyed');
+  if (checkFinished && instance.finished) throw new Error('Hash#digest() has already been called');
+}
+
+/** Asserts output is properly-sized byte array */
+export function aoutput(out: any, instance: any): void {
+  abytes(out);
+  const min = instance.outputLen;
+  if (out.length < min) {
+    throw new Error('digestInto() expects output buffer of length at least ' + min);
+  }
+}
+
+/** Generic type encompassing 8/16/32-byte arrays - but not 64-byte. */
+// prettier-ignore
+export type TypedArray = Int8Array | Uint8ClampedArray | Uint8Array |
+  Uint16Array | Int16Array | Uint32Array | Int32Array;
+
+/** Cast u8 / u16 / u32 to u8. */
+export function u8(arr: TypedArray): Uint8Array {
+  return new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+}
+
+/** Cast u8 / u16 / u32 to u32. */
+export function u32(arr: TypedArray): Uint32Array {
+  return new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
+}
+
+/** Zeroize a byte array. Warning: JS provides no guarantees. */
+export function clean(...arrays: TypedArray[]): void {
+  for (let i = 0; i < arrays.length; i++) {
+    arrays[i].fill(0);
+  }
+}
+
+/** Create DataView of an array for easy byte-level manipulation. */
+export function createView(arr: TypedArray): DataView {
+  return new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+}
+
+/** The rotate right (circular right shift) operation for uint32 */
+export function rotr(word: number, shift: number): number {
+  return (word << (32 - shift)) | (word >>> shift);
+}
+
+/** The rotate left (circular left shift) operation for uint32 */
+export function rotl(word: number, shift: number): number {
+  return (word << shift) | ((word >>> (32 - shift)) >>> 0);
+}
+
+/** Is current platform little-endian? Most are. Big-Endian platform: IBM */
+export const isLE: boolean = /* @__PURE__ */ (() =>
+  new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44)();
+
+/** The byte swap operation for uint32 */
+export function byteSwap(word: number): number {
+  return (
+    ((word << 24) & 0xff000000) |
+    ((word << 8) & 0xff0000) |
+    ((word >>> 8) & 0xff00) |
+    ((word >>> 24) & 0xff)
+  );
+}
+/** Conditionally byte swap if on a big-endian platform */
+export const swap8IfBE: (n: number) => number = isLE
+  ? (n: number) => n
+  : (n: number) => byteSwap(n);
+
+/** @deprecated */
+export const byteSwapIfBE: typeof swap8IfBE = swap8IfBE;
+/** In place byte swap for Uint32Array */
+export function byteSwap32(arr: Uint32Array): Uint32Array {
+  for (let i = 0; i < arr.length; i++) {
+    arr[i] = byteSwap(arr[i]);
+  }
+  return arr;
+}
+
+export const swap32IfBE: (u: Uint32Array) => Uint32Array = isLE
+  ? (u: Uint32Array) => u
+  : byteSwap32;
+
+// Built-in hex conversion https://caniuse.com/mdn-javascript_builtins_uint8array_fromhex
+const hasHexBuiltin: boolean = /* @__PURE__ */ (() =>
+  // @ts-ignore
+  typeof Uint8Array.from([]).toHex === 'function' && typeof Uint8Array.fromHex === 'function')();
+
+// Array where index 0xf0 (240) is mapped to string 'f0'
+const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) =>
+  i.toString(16).padStart(2, '0')
+);
+
+/**
+ * Convert byte array to hex string. Uses built-in function, when available.
+ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
+ */
+export function bytesToHex(bytes: Uint8Array): string {
+  abytes(bytes);
+  // @ts-ignore
+  if (hasHexBuiltin) return bytes.toHex();
+  // pre-caching improves the speed 6x
+  let hex = '';
+  for (let i = 0; i < bytes.length; i++) {
+    hex += hexes[bytes[i]];
+  }
+  return hex;
+}
+
+// We use optimized technique to convert hex string to byte array
+const asciis = { _0: 48, _9: 57, A: 65, F: 70, a: 97, f: 102 } as const;
+function asciiToBase16(ch: number): number | undefined {
+  if (ch >= asciis._0 && ch <= asciis._9) return ch - asciis._0; // '2' => 50-48
+  if (ch >= asciis.A && ch <= asciis.F) return ch - (asciis.A - 10); // 'B' => 66-(65-10)
+  if (ch >= asciis.a && ch <= asciis.f) return ch - (asciis.a - 10); // 'b' => 98-(97-10)
+  return;
+}
+
+/**
+ * Convert hex string to byte array. Uses built-in function, when available.
+ * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
+ */
+export function hexToBytes(hex: string): Uint8Array {
+  if (typeof hex !== 'string') throw new Error('hex string expected, got ' + typeof hex);
+  // @ts-ignore
+  if (hasHexBuiltin) return Uint8Array.fromHex(hex);
+  const hl = hex.length;
+  const al = hl / 2;
+  if (hl % 2) throw new Error('hex string expected, got unpadded hex of length ' + hl);
+  const array = new Uint8Array(al);
+  for (let ai = 0, hi = 0; ai < al; ai++, hi += 2) {
+    const n1 = asciiToBase16(hex.charCodeAt(hi));
+    const n2 = asciiToBase16(hex.charCodeAt(hi + 1));
+    if (n1 === undefined || n2 === undefined) {
+      const char = hex[hi] + hex[hi + 1];
+      throw new Error('hex string expected, got non-hex character "' + char + '" at index ' + hi);
+    }
+    array[ai] = n1 * 16 + n2; // multiply first octet, e.g. 'a3' => 10*16+3 => 160 + 3 => 163
+  }
+  return array;
+}
+
+/**
+ * There is no setImmediate in browser and setTimeout is slow.
+ * Call of async fn will return Promise, which will be fullfiled only on
+ * next scheduler queue processing step and this is exactly what we need.
+ */
+export const nextTick = async (): Promise<void> => {};
+
+/** Returns control to thread each 'tick' ms to avoid blocking. */
+export async function asyncLoop(
+  iters: number,
+  tick: number,
+  cb: (i: number) => void
+): Promise<void> {
+  let ts = Date.now();
+  for (let i = 0; i < iters; i++) {
+    cb(i);
+    // Date.now() is not monotonic, so in case if clock goes backwards we return return control too
+    const diff = Date.now() - ts;
+    if (diff >= 0 && diff < tick) continue;
+    await nextTick();
+    ts += diff;
+  }
+}
+
+// Global symbols, but ts doesn't see them: https://github.com/microsoft/TypeScript/issues/31535
+declare const TextEncoder: any;
+declare const TextDecoder: any;
+
+/**
+ * Converts string to bytes using UTF8 encoding.
+ * @example utf8ToBytes('abc') // Uint8Array.from([97, 98, 99])
+ */
+export function utf8ToBytes(str: string): Uint8Array {
+  if (typeof str !== 'string') throw new Error('string expected');
+  return new Uint8Array(new TextEncoder().encode(str)); // https://bugzil.la/1681809
+}
+
+/**
+ * Converts bytes to string using UTF8 encoding.
+ * @example bytesToUtf8(Uint8Array.from([97, 98, 99])) // 'abc'
+ */
+export function bytesToUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+/** Accepted input of hash functions. Strings are converted to byte arrays. */
+export type Input = string | Uint8Array;
+/**
+ * Normalizes (non-hex) string or Uint8Array to Uint8Array.
+ * Warning: when Uint8Array is passed, it would NOT get copied.
+ * Keep in mind for future mutable operations.
+ */
+export function toBytes(data: Input): Uint8Array {
+  if (typeof data === 'string') data = utf8ToBytes(data);
+  abytes(data);
+  return data;
+}
+
+/** KDFs can accept string or Uint8Array for user convenience. */
+export type KDFInput = string | Uint8Array;
+/**
+ * Helper for KDFs: consumes uint8array or string.
+ * When string is passed, does utf8 decoding, using TextDecoder.
+ */
+export function kdfInputToBytes(data: KDFInput): Uint8Array {
+  if (typeof data === 'string') data = utf8ToBytes(data);
+  abytes(data);
+  return data;
+}
+
+/** Copies several Uint8Arrays into one. */
+export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  let sum = 0;
+  for (let i = 0; i < arrays.length; i++) {
+    const a = arrays[i];
+    abytes(a);
+    sum += a.length;
+  }
+  const res = new Uint8Array(sum);
+  for (let i = 0, pad = 0; i < arrays.length; i++) {
+    const a = arrays[i];
+    res.set(a, pad);
+    pad += a.length;
+  }
+  return res;
+}
+
+type EmptyObj = {};
+export function checkOpts<T1 extends EmptyObj, T2 extends EmptyObj>(
+  defaults: T1,
+  opts?: T2
+): T1 & T2 {
+  if (opts !== undefined && {}.toString.call(opts) !== '[object Object]')
+    throw new Error('options should be object or undefined');
+  const merged = Object.assign(defaults, opts);
+  return merged as T1 & T2;
+}
+
+/** Hash interface. */
+export type IHash = {
+  (data: Uint8Array): Uint8Array;
+  blockLen: number;
+  outputLen: number;
+  create: any;
+};
+
+/** For runtime check if class implements interface */
+export abstract class Hash<T extends Hash<T>> {
+  abstract blockLen: number; // Bytes per block
+  abstract outputLen: number; // Bytes in output
+  abstract update(buf: Input): this;
+  // Writes digest into buf
+  abstract digestInto(buf: Uint8Array): void;
+  abstract digest(): Uint8Array;
+  /**
+   * Resets internal state. Makes Hash instance unusable.
+   * Reset is impossible for keyed hashes if key is consumed into state. If digest is not consumed
+   * by user, they will need to manually call `destroy()` when zeroing is necessary.
+   */
+  abstract destroy(): void;
+  /**
+   * Clones hash instance. Unsafe: doesn't check whether `to` is valid. Can be used as `clone()`
+   * when no options are passed.
+   * Reasons to use `_cloneInto` instead of clone: 1) performance 2) reuse instance => all internal
+   * buffers are overwritten => causes buffer overwrite which is used for digest in some cases.
+   * There are no guarantees for clean-up because it's impossible in JS.
+   */
+  abstract _cloneInto(to?: T): T;
+  // Safe version that clones internal state
+  abstract clone(): T;
+}
+
+/**
+ * XOF: streaming API to read digest in chunks.
+ * Same as 'squeeze' in keccak/k12 and 'seek' in blake3, but more generic name.
+ * When hash used in XOF mode it is up to user to call '.destroy' afterwards, since we cannot
+ * destroy state, next call can require more bytes.
+ */
+export type HashXOF<T extends Hash<T>> = Hash<T> & {
+  xof(bytes: number): Uint8Array; // Read 'bytes' bytes from digest stream
+  xofInto(buf: Uint8Array): Uint8Array; // read buf.length bytes from digest stream into buf
+};
+
+/** Hash function */
+export type CHash = ReturnType<typeof createHasher>;
+/** Hash function with output */
+export type CHashO = ReturnType<typeof createOptHasher>;
+/** XOF with output */
+export type CHashXO = ReturnType<typeof createXOFer>;
+
+/** Wraps hash function, creating an interface on top of it */
+export function createHasher<T extends Hash<T>>(
+  hashCons: () => Hash<T>
+): {
+  (msg: Input): Uint8Array;
+  outputLen: number;
+  blockLen: number;
+  create(): Hash<T>;
+} {
+  const hashC = (msg: Input): Uint8Array => hashCons().update(toBytes(msg)).digest();
+  const tmp = hashCons();
+  hashC.outputLen = tmp.outputLen;
+  hashC.blockLen = tmp.blockLen;
+  hashC.create = () => hashCons();
+  return hashC;
+}
+
+export function createOptHasher<H extends Hash<H>, T extends Object>(
+  hashCons: (opts?: T) => Hash<H>
+): {
+  (msg: Input, opts?: T): Uint8Array;
+  outputLen: number;
+  blockLen: number;
+  create(opts?: T): Hash<H>;
+} {
+  const hashC = (msg: Input, opts?: T): Uint8Array => hashCons(opts).update(toBytes(msg)).digest();
+  const tmp = hashCons({} as T);
+  hashC.outputLen = tmp.outputLen;
+  hashC.blockLen = tmp.blockLen;
+  hashC.create = (opts?: T) => hashCons(opts);
+  return hashC;
+}
+
+export function createXOFer<H extends HashXOF<H>, T extends Object>(
+  hashCons: (opts?: T) => HashXOF<H>
+): {
+  (msg: Input, opts?: T): Uint8Array;
+  outputLen: number;
+  blockLen: number;
+  create(opts?: T): HashXOF<H>;
+} {
+  const hashC = (msg: Input, opts?: T): Uint8Array => hashCons(opts).update(toBytes(msg)).digest();
+  const tmp = hashCons({} as T);
+  hashC.outputLen = tmp.outputLen;
+  hashC.blockLen = tmp.blockLen;
+  hashC.create = (opts?: T) => hashCons(opts);
+  return hashC;
+}
+export const wrapConstructor: typeof createHasher = createHasher;
+export const wrapConstructorWithOpts: typeof createOptHasher = createOptHasher;
+export const wrapXOFConstructorWithOpts: typeof createXOFer = createXOFer;
+
+/** Cryptographically secure PRNG. Uses internal OS-level `crypto.getRandomValues`. */
+export function randomBytes(bytesLength = 32): Uint8Array {
+  if (typeof globalThis !== 'undefined' && globalThis.crypto && typeof globalThis.crypto.getRandomValues === 'function') {
+    return globalThis.crypto.getRandomValues(new Uint8Array(bytesLength));
+  }
+  throw new Error('crypto.getRandomValues must be defined');
+}


### PR DESCRIPTION
## Summary
- add a fast PBKDF2-SHA512 implementation derived from `noble-hashes`
- fallback to this new version when Node's pbkdf2Sync isn't available

## Testing
- `npm test`
- `npm run build:ts`

------
https://chatgpt.com/codex/tasks/task_e_687ee908ecd8832e93e778e4bfe5a249