### PR TITLE
Improve hashing performance

### DIFF
--- a/src/primitives/Hash.ts
+++ b/src/primitives/Hash.ts
@@ -326,6 +326,12 @@ function zero8 (word: string): string {
   }
 }
 
+function bytesToHex (data: Uint8Array): string {
+  let res = ''
+  for (const b of data) res += b.toString(16).padStart(2, '0')
+  return res
+}
+
 function join32 (msg, start, end, endian): number[] {
   const len = end - start
   assert(len % 4 === 0)
@@ -721,88 +727,21 @@ export class RIPEMD160 extends BaseHash {
  * @property W - Provides a way to recycle usage of the array memory.
  * @property k - The round constants used for each round of SHA-256
  */
-export class SHA256 extends BaseHash {
-  h: number[]
-  W: number[]
-  k: number[]
-
+export class SHA256 {
+  private readonly h: FastSHA256
   constructor () {
-    super(512, 256, 192, 64)
-    this.h = [
-      0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
-      0x1f83d9ab, 0x5be0cd19
-    ]
-    this.k = [
-      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
-      0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-      0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
-      0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
-      0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-      0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-      0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
-      0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-      0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
-    ]
-    this.W = new Array(64)
+    this.h = new FastSHA256()
   }
-
-  _update (msg: number[], start?: number): void {
-    const W = this.W
-
-    // Default start to 0
-    if (start === undefined) {
-      start = 0
-    }
-
-    let i: number
-    for (i = 0; i < 16; i++) {
-      W[i] = msg[start + i]
-    }
-    for (; i < W.length; i++) {
-      W[i] = SUM32_4(G1_256(W[i - 2]), W[i - 7], G0_256(W[i - 15]), W[i - 16])
-    }
-
-    let a = this.h[0]
-    let b = this.h[1]
-    let c = this.h[2]
-    let d = this.h[3]
-    let e = this.h[4]
-    let f = this.h[5]
-    let g = this.h[6]
-    let h = this.h[7]
-
-    assert(this.k.length === W.length)
-    for (i = 0; i < W.length; i++) {
-      const T1 = SUM32_5(h, S1_256(e), ch32(e, f, g), this.k[i], W[i])
-      const T2 = sum32(S0_256(a), maj32(a, b, c))
-      h = g
-      g = f
-      f = e
-      e = sum32(d, T1)
-      d = c
-      c = b
-      b = a
-      a = sum32(T1, T2)
-    }
-
-    this.h[0] = sum32(this.h[0], a)
-    this.h[1] = sum32(this.h[1], b)
-    this.h[2] = sum32(this.h[2], c)
-    this.h[3] = sum32(this.h[3], d)
-    this.h[4] = sum32(this.h[4], e)
-    this.h[5] = sum32(this.h[5], f)
-    this.h[6] = sum32(this.h[6], g)
-    this.h[7] = sum32(this.h[7], h)
+  update (msg: number[] | string, enc?: 'hex' | 'utf8'): this {
+    const data = Uint8Array.from(toArray(msg, enc))
+    this.h.update(data)
+    return this
   }
-
-  _digest (): number[] {
-    return split32(this.h, 'big')
+  digest (): number[] {
+    return Array.from(this.h.digest())
   }
-
-  _digestHex (): string {
-    return toHex32(this.h, 'big')
+  digestHex (): string {
+    return bytesToHex(this.h.digest())
   }
 }
 
@@ -905,192 +844,21 @@ export class SHA1 extends BaseHash {
  * @property W - Provides a way to recycle usage of the array memory.
  * @property k - The round constants used for each round of SHA-512.
  */
-export class SHA512 extends BaseHash {
-  h: number[]
-  W: number[]
-  k: number[]
-
+export class SHA512 {
+  private readonly h: FastSHA512
   constructor () {
-    super(1024, 512, 192, 128)
-    this.h = [
-      0x6a09e667, 0xf3bcc908, 0xbb67ae85, 0x84caa73b, 0x3c6ef372, 0xfe94f82b,
-      0xa54ff53a, 0x5f1d36f1, 0x510e527f, 0xade682d1, 0x9b05688c, 0x2b3e6c1f,
-      0x1f83d9ab, 0xfb41bd6b, 0x5be0cd19, 0x137e2179
-    ]
-    this.k = [
-      0x428a2f98, 0xd728ae22, 0x71374491, 0x23ef65cd, 0xb5c0fbcf, 0xec4d3b2f,
-      0xe9b5dba5, 0x8189dbbc, 0x3956c25b, 0xf348b538, 0x59f111f1, 0xb605d019,
-      0x923f82a4, 0xaf194f9b, 0xab1c5ed5, 0xda6d8118, 0xd807aa98, 0xa3030242,
-      0x12835b01, 0x45706fbe, 0x243185be, 0x4ee4b28c, 0x550c7dc3, 0xd5ffb4e2,
-      0x72be5d74, 0xf27b896f, 0x80deb1fe, 0x3b1696b1, 0x9bdc06a7, 0x25c71235,
-      0xc19bf174, 0xcf692694, 0xe49b69c1, 0x9ef14ad2, 0xefbe4786, 0x384f25e3,
-      0x0fc19dc6, 0x8b8cd5b5, 0x240ca1cc, 0x77ac9c65, 0x2de92c6f, 0x592b0275,
-      0x4a7484aa, 0x6ea6e483, 0x5cb0a9dc, 0xbd41fbd4, 0x76f988da, 0x831153b5,
-      0x983e5152, 0xee66dfab, 0xa831c66d, 0x2db43210, 0xb00327c8, 0x98fb213f,
-      0xbf597fc7, 0xbeef0ee4, 0xc6e00bf3, 0x3da88fc2, 0xd5a79147, 0x930aa725,
-      0x06ca6351, 0xe003826f, 0x14292967, 0x0a0e6e70, 0x27b70a85, 0x46d22ffc,
-      0x2e1b2138, 0x5c26c926, 0x4d2c6dfc, 0x5ac42aed, 0x53380d13, 0x9d95b3df,
-      0x650a7354, 0x8baf63de, 0x766a0abb, 0x3c77b2a8, 0x81c2c92e, 0x47edaee6,
-      0x92722c85, 0x1482353b, 0xa2bfe8a1, 0x4cf10364, 0xa81a664b, 0xbc423001,
-      0xc24b8b70, 0xd0f89791, 0xc76c51a3, 0x0654be30, 0xd192e819, 0xd6ef5218,
-      0xd6990624, 0x5565a910, 0xf40e3585, 0x5771202a, 0x106aa070, 0x32bbd1b8,
-      0x19a4c116, 0xb8d2d0c8, 0x1e376c08, 0x5141ab53, 0x2748774c, 0xdf8eeb99,
-      0x34b0bcb5, 0xe19b48a8, 0x391c0cb3, 0xc5c95a63, 0x4ed8aa4a, 0xe3418acb,
-      0x5b9cca4f, 0x7763e373, 0x682e6ff3, 0xd6b2b8a3, 0x748f82ee, 0x5defb2fc,
-      0x78a5636f, 0x43172f60, 0x84c87814, 0xa1f0ab72, 0x8cc70208, 0x1a6439ec,
-      0x90befffa, 0x23631e28, 0xa4506ceb, 0xde82bde9, 0xbef9a3f7, 0xb2c67915,
-      0xc67178f2, 0xe372532b, 0xca273ece, 0xea26619c, 0xd186b8c7, 0x21c0c207,
-      0xeada7dd6, 0xcde0eb1e, 0xf57d4f7f, 0xee6ed178, 0x06f067aa, 0x72176fba,
-      0x0a637dc5, 0xa2c898a6, 0x113f9804, 0xbef90dae, 0x1b710b35, 0x131c471b,
-      0x28db77f5, 0x23047d84, 0x32caab7b, 0x40c72493, 0x3c9ebe0a, 0x15c9bebc,
-      0x431d67c4, 0x9c100d4c, 0x4cc5d4be, 0xcb3e42b6, 0x597f299c, 0xfc657e2a,
-      0x5fcb6fab, 0x3ad6faec, 0x6c44198c, 0x4a475817
-    ]
-    this.W = new Array(160)
+    this.h = new FastSHA512()
   }
-
-  _prepareBlock (msg: number[], start: number): void {
-    const W = this.W
-
-    // 32 x 32bit words
-    let i: number
-    for (i = 0; i < 32; i++) {
-      W[i] = msg[start + i]
-    }
-    for (; i < W.length; i += 2) {
-      const c0Hi = g1_512_hi(W[i - 4], W[i - 3]) // i - 2
-      const c0Lo = g1_512_lo(W[i - 4], W[i - 3])
-      const c1Hi = W[i - 14] // i - 7
-      const c1Lo = W[i - 13]
-      const c2Hi = g0_512_hi(W[i - 30], W[i - 29]) // i - 15
-      const c2Lo = g0_512_lo(W[i - 30], W[i - 29])
-      const c3Hi = W[i - 32] // i - 16
-      const c3Lo = W[i - 31]
-
-      W[i] = sum64and4HI(c0Hi, c0Lo, c1Hi, c1Lo, c2Hi, c2Lo, c3Hi, c3Lo)
-      W[i + 1] = sum64and4LO(
-        c0Hi,
-        c0Lo,
-        c1Hi,
-        c1Lo,
-        c2Hi,
-        c2Lo,
-        c3Hi,
-        c3Lo
-      )
-    }
+  update (msg: number[] | string, enc?: 'hex' | 'utf8'): this {
+    const data = Uint8Array.from(toArray(msg, enc))
+    this.h.update(data)
+    return this
   }
-
-  _update (msg: any, start: number): void {
-    this._prepareBlock(msg, start)
-
-    const W = this.W
-
-    let aHigh = this.h[0]
-    let aLow = this.h[1]
-    let bHigh = this.h[2]
-    let bLow = this.h[3]
-    let cHigh = this.h[4]
-    let cLow = this.h[5]
-    let dHigh = this.h[6]
-    let dLow = this.h[7]
-    let eHigh = this.h[8]
-    let eLow = this.h[9]
-    let fHigh = this.h[10]
-    let fLow = this.h[11]
-    let gHigh = this.h[12]
-    let gLow = this.h[13]
-    let hHigh = this.h[14]
-    let hLow = this.h[15]
-
-    assert(this.k.length === W.length)
-
-    for (let i = 0; i < W.length; i += 2) {
-      let temp0High = hHigh
-      let temp0Low = hLow
-      let temp1High = s1_512_hi(eHigh, eLow)
-      let temp1Low = s1_512_lo(eHigh, eLow)
-      const temp2High = ch64_hi(eHigh, eLow, fHigh, fLow, gHigh, gLow)
-      const temp2Low = ch64_lo(eHigh, eLow, fHigh, fLow, gHigh, gLow)
-      const temp3High = this.k[i]
-      const temp3Low = this.k[i + 1]
-      const temp4High = W[i]
-      const temp4Low = W[i + 1]
-
-      const t1High = sum64and5HI(
-        temp0High,
-        temp0Low,
-        temp1High,
-        temp1Low,
-        temp2High,
-        temp2Low,
-        temp3High,
-        temp3Low,
-        temp4High,
-        temp4Low
-      )
-      const t1Low = sum64and5LO(
-        temp0High,
-        temp0Low,
-        temp1High,
-        temp1Low,
-        temp2High,
-        temp2Low,
-        temp3High,
-        temp3Low,
-        temp4High,
-        temp4Low
-      )
-
-      temp0High = s0_512_hi(aHigh, aLow)
-      temp0Low = s0_512_lo(aHigh, aLow)
-      temp1High = maj64_hi(aHigh, aLow, bHigh, bLow, cHigh, cLow)
-      temp1Low = maj64_lo(aHigh, aLow, bHigh, bLow, cHigh, cLow)
-
-      const t2High = sum64HI(temp0High, temp0Low, temp1High, temp1Low)
-      const t2Low = sum64LO(temp0High, temp0Low, temp1High, temp1Low)
-
-      hHigh = gHigh
-      hLow = gLow
-
-      gHigh = fHigh
-      gLow = fLow
-
-      fHigh = eHigh
-      fLow = eLow
-
-      eHigh = sum64HI(dHigh, dLow, t1High, t1Low)
-      eLow = sum64LO(dLow, dLow, t1High, t1Low)
-
-      dHigh = cHigh
-      dLow = cLow
-
-      cHigh = bHigh
-      cLow = bLow
-
-      bHigh = aHigh
-      bLow = aLow
-
-      aHigh = sum64HI(t1High, t1Low, t2High, t2Low)
-      aLow = sum64LO(t1High, t1Low, t2High, t2Low)
-    }
-
-    sum64(this.h, 0, aHigh, aLow)
-    sum64(this.h, 2, bHigh, bLow)
-    sum64(this.h, 4, cHigh, cLow)
-    sum64(this.h, 6, dHigh, dLow)
-    sum64(this.h, 8, eHigh, eLow)
-    sum64(this.h, 10, fHigh, fLow)
-    sum64(this.h, 12, gHigh, gLow)
-    sum64(this.h, 14, hHigh, hLow)
+  digest (): number[] {
+    return Array.from(this.h.digest())
   }
-
-  _digest (): number[] {
-    return split32(this.h, 'big')
-  }
-
-  _digestHex (): string {
-    return toHex32(this.h, 'big')
+  digestHex (): string {
+    return bytesToHex(this.h.digest())
   }
 }
 
@@ -1235,8 +1003,7 @@ function g1_512_lo (xh: number, xl: number): number {
  * @property outSize - The output size of the SHA-256 hash function, in bytes. It's set to 32 bytes.
  */
 export class SHA256HMAC {
-  inner: SHA256
-  outer: SHA256
+  private readonly h: HMAC<FastSHA256>
   blockSize = 64
   outSize = 32
 
@@ -1254,29 +1021,8 @@ export class SHA256HMAC {
    * const myHMAC = new SHA256HMAC('deadbeef');
    */
   constructor (key: number[] | string) {
-    key = toArray(key, 'hex')
-    // Shorten key, if needed
-    if (key.length > this.blockSize) {
-      key = new SHA256().update(key).digest()
-    }
-    assert(key.length <= this.blockSize)
-
-    // Add padding to key
-    let i
-    for (i = key.length; i < this.blockSize; i++) {
-      key.push(0)
-    }
-
-    for (i = 0; i < key.length; i++) {
-      key[i] ^= 0x36
-    }
-    this.inner = new SHA256().update(key)
-
-    // 0x36 ^ 0x5c = 0x6a
-    for (i = 0; i < key.length; i++) {
-      key[i] ^= 0x6a
-    }
-    this.outer = new SHA256().update(key)
+    const k = Uint8Array.from(toArray(key, 'hex'))
+    this.h = new HMAC(sha256Fast, k)
   }
 
   /**
@@ -1291,7 +1037,7 @@ export class SHA256HMAC {
    * myHMAC.update('deadbeef', 'hex');
    */
   update (msg: number[] | string, enc?: 'hex'): SHA256HMAC {
-    this.inner.update(msg, enc)
+    this.h.update(Uint8Array.from(toArray(msg, enc)))
     return this
   }
 
@@ -1305,8 +1051,7 @@ export class SHA256HMAC {
    * let hashedMessage = myHMAC.digest();
    */
   digest (): number[] {
-    this.outer.update(this.inner.digest())
-    return this.outer.digest()
+    return Array.from(this.h.digest())
   }
 
   /**
@@ -1319,8 +1064,7 @@ export class SHA256HMAC {
    * let hashedMessage = myHMAC.digestHex();
    */
   digestHex (): string {
-    this.outer.update(this.inner.digest())
-    return this.outer.digestHex()
+    return bytesToHex(this.h.digest())
   }
 }
 
@@ -1383,8 +1127,7 @@ export class SHA1HMAC {
  * @property outSize - The output size of the SHA-512 hash function, in bytes. It's set to 64 bytes.
  */
 export class SHA512HMAC {
-  inner: SHA512
-  outer: SHA512
+  private readonly h: HMAC<FastSHA512>
   blockSize = 128
   outSize = 32
 
@@ -1402,29 +1145,8 @@ export class SHA512HMAC {
    * const myHMAC = new SHA512HMAC('deadbeef');
    */
   constructor (key: number[] | string) {
-    key = toArray(key, 'hex')
-    // Shorten key, if needed
-    if (key.length > this.blockSize) {
-      key = new SHA512().update(key).digest()
-    }
-    assert(key.length <= this.blockSize)
-
-    // Add padding to key
-    let i
-    for (i = key.length; i < this.blockSize; i++) {
-      key.push(0)
-    }
-
-    for (i = 0; i < key.length; i++) {
-      key[i] ^= 0x36
-    }
-    this.inner = new SHA512().update(key)
-
-    // 0x36 ^ 0x5c = 0x6a
-    for (i = 0; i < key.length; i++) {
-      key[i] ^= 0x6a
-    }
-    this.outer = new SHA512().update(key)
+    const k = Uint8Array.from(toArray(key, 'hex'))
+    this.h = new HMAC(sha512Fast, k)
   }
 
   /**
@@ -1439,7 +1161,7 @@ export class SHA512HMAC {
    * myHMAC.update('deadbeef', 'hex');
    */
   update (msg: number[] | string, enc?: 'hex' | 'utf8'): SHA512HMAC {
-    this.inner.update(msg, enc)
+    this.h.update(Uint8Array.from(toArray(msg, enc)))
     return this
   }
 
@@ -1453,8 +1175,7 @@ export class SHA512HMAC {
    * let hashedMessage = myHMAC.digest();
    */
   digest (): number[] {
-    this.outer.update(this.inner.digest())
-    return this.outer.digest()
+    return Array.from(this.h.digest())
   }
 
   /**
@@ -1467,8 +1188,7 @@ export class SHA512HMAC {
    * let hashedMessage = myHMAC.digestHex();
    */
   digestHex (): string {
-    this.outer.update(this.inner.digest())
-    return this.outer.digestHex()
+    return bytesToHex(this.h.digest())
   }
 }
 
@@ -1872,6 +1592,110 @@ function setBigUint64 (view: DataView, byteOffset: number, value: bigint, isLE: 
   view.setUint32(byteOffset + h, wh, isLE)
   view.setUint32(byteOffset + l, wl, isLE)
 }
+
+// sha256 fast constants
+const SHA256_IV = Uint32Array.from([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+])
+const K256 = Uint32Array.from([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+])
+const SHA256_W = new Uint32Array(64)
+
+class FastSHA256 extends HashMD<FastSHA256> {
+  protected A = SHA256_IV[0] | 0
+  protected B = SHA256_IV[1] | 0
+  protected C = SHA256_IV[2] | 0
+  protected D = SHA256_IV[3] | 0
+  protected E = SHA256_IV[4] | 0
+  protected F = SHA256_IV[5] | 0
+  protected G = SHA256_IV[6] | 0
+  protected H = SHA256_IV[7] | 0
+  constructor (outputLen = 32) {
+    super(64, outputLen, 8, false)
+  }
+
+  protected get (): number[] {
+    const { A, B, C, D, E, F, G, H } = this
+    return [A, B, C, D, E, F, G, H]
+  }
+
+  protected set (
+    A: number,
+    B: number,
+    C: number,
+    D: number,
+    E: number,
+    F: number,
+    G: number,
+    H: number
+  ): void {
+    this.A = A | 0
+    this.B = B | 0
+    this.C = C | 0
+    this.D = D | 0
+    this.E = E | 0
+    this.F = F | 0
+    this.G = G | 0
+    this.H = H | 0
+  }
+
+  protected process (view: DataView, offset: number): void {
+    for (let i = 0; i < 16; i++, offset += 4) {
+      SHA256_W[i] = view.getUint32(offset)
+    }
+    for (let i = 16; i < 64; i++) {
+      const w15 = SHA256_W[i - 15]
+      const w2 = SHA256_W[i - 2]
+      const s0 = G0_256(w15)
+      const s1 = G1_256(w2)
+      SHA256_W[i] = sum32(sum32(s0, SHA256_W[i - 7]), sum32(s1, SHA256_W[i - 16]))
+    }
+
+    let { A, B, C, D, E, F, G, H } = this
+    for (let i = 0; i < 64; i++) {
+      const T1 = SUM32_5(H, S1_256(E), ch32(E, F, G), K256[i], SHA256_W[i])
+      const T2 = sum32(S0_256(A), maj32(A, B, C))
+      H = G
+      G = F
+      F = E
+      E = sum32(D, T1)
+      D = C
+      C = B
+      B = A
+      A = sum32(T1, T2)
+    }
+    this.A = sum32(this.A, A)
+    this.B = sum32(this.B, B)
+    this.C = sum32(this.C, C)
+    this.D = sum32(this.D, D)
+    this.E = sum32(this.E, E)
+    this.F = sum32(this.F, F)
+    this.G = sum32(this.G, G)
+    this.H = sum32(this.H, H)
+  }
+
+  protected roundClean (): void {
+    clean(SHA256_W)
+  }
+
+  destroy (): void {
+    clean(this.buffer)
+    this.set(0, 0, 0, 0, 0, 0, 0, 0)
+  }
+}
+const sha256Fast = createHasher(() => new FastSHA256())
 
 // sha512
 const SHA512_IV = Uint32Array.from([


### PR DESCRIPTION
## Summary
- implement optimized SHA256 using FastSHA256
- add typed-array based wrappers for SHA256 and SHA512
- update HMAC implementations to use fast hashes
- helper for converting bytes to hex

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f0eacab2c832ead8e6d3ebc7b39e4