### PR TITLE
Optimize Atomic BEEF serialization performance

### DIFF
--- a/benchmarks/atomic-beef-bench.js
+++ b/benchmarks/atomic-beef-bench.js
@@ -1,0 +1,78 @@
+import { performance } from 'perf_hooks'
+import Transaction from '../dist/esm/src/transaction/Transaction.js'
+import PrivateKey from '../dist/esm/src/primitives/PrivateKey.js'
+import P2PKH from '../dist/esm/src/script/templates/P2PKH.js'
+
+async function buildChain (depth) {
+  const privateKey = new PrivateKey(1)
+  const publicKeyHash = privateKey.toPublicKey().toHash()
+  const p2pkh = new P2PKH()
+
+  const baseTx = new Transaction()
+  baseTx.addOutput({
+    lockingScript: p2pkh.lock(publicKeyHash),
+    satoshis: 100000
+  })
+
+  let currentTx = baseTx
+
+  for (let i = 1; i < depth; i++) {
+    const nextTx = new Transaction()
+    nextTx.addInput({
+      sourceTransaction: currentTx,
+      sourceOutputIndex: 0,
+      unlockingScriptTemplate: p2pkh.unlock(privateKey),
+      sequence: 0xffffffff
+    })
+    nextTx.addOutput({
+      lockingScript: p2pkh.lock(publicKeyHash),
+      satoshis: 100000 - i
+    })
+    await nextTx.sign()
+    currentTx = nextTx
+  }
+
+  return currentTx
+}
+
+async function measure (fn, iterations = 5) {
+  const times = []
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now()
+    const result = fn()
+    if (result instanceof Promise) {
+      await result
+    }
+    const end = performance.now()
+    times.push(end - start)
+  }
+  const total = times.reduce((sum, t) => sum + t, 0)
+  return {
+    average: total / times.length,
+    min: Math.min(...times),
+    max: Math.max(...times)
+  }
+}
+
+async function run () {
+  const depth = Number.parseInt(process.argv[2] ?? '200', 10)
+  const iterations = Number.parseInt(process.argv[3] ?? '5', 10)
+  console.log(`Building transaction chain with depth ${depth} ...`)
+  const finalTx = await buildChain(depth)
+
+  console.log('Warming up serializers/deserializers ...')
+  const initialSerialized = finalTx.toAtomicBEEF()
+  Transaction.fromAtomicBEEF(initialSerialized)
+
+  const toStats = await measure(() => finalTx.toAtomicBEEF(), iterations)
+  const serialized = finalTx.toAtomicBEEF()
+  const fromStats = await measure(() => Transaction.fromAtomicBEEF(serialized), iterations)
+
+  console.log(`Transaction.toAtomicBEEF avg: ${toStats.average.toFixed(2)}ms (min ${toStats.min.toFixed(2)}ms, max ${toStats.max.toFixed(2)}ms)`) 
+  console.log(`Transaction.fromAtomicBEEF avg: ${fromStats.average.toFixed(2)}ms (min ${fromStats.min.toFixed(2)}ms, max ${fromStats.max.toFixed(2)}ms)`) 
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add an Atomic BEEF benchmark that constructs deep dependent transaction chains and reports serializer/deserializer timings
- optimize Transaction.toBEEF to reuse computed BUMP indexes and avoid O(n^2) duplicate detection when serializing Atomic BEEF
- cache Beef transaction lookups with a txid index to speed up Atomic BEEF deserialization and keep the index synchronized as the set mutates; end-to-end benchmark time dropped from ~52ms/19ms to ~5.6ms/12ms for toAtomicBEEF/fromAtomicBEEF on a 200-deep chain

## Testing
- npm test -- Transaction
- node benchmarks/atomic-beef-bench.js 200 5

------
https://chatgpt.com/codex/tasks/task_e_68ce11c59fc4832eae7335eb8eb257df