### PR TITLE
Fix script shift endianness and add regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.9.8 - 2025-11-15](#198---2025-11-15)
 - [1.9.7 - 2025-11-14](#197---2025-11-14)
 - [1.9.6 - 2025-11-13](#196---2025-11-13)
 - [1.9.5 - 2025-11-13](#195---2025-11-13)
@@ -177,6 +178,14 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+### [1.9.8] - 2025-11-15
+
+### Fixed
+
+- Ensured `OP_LSHIFT` and `OP_RSHIFT` maintain the original stack element endianness and added regression tests covering the bug.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.9.7",
+      "version": "1.9.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/script/Spend.ts
+++ b/src/script/Spend.ts
@@ -667,7 +667,7 @@ export default class Spend {
           if (currentOpcode === OP.OP_LSHIFT) shiftedBn = bn1.ushln(shiftBits)
           else shiftedBn = bn1.ushrn(shiftBits)
 
-          const shiftedArr = shiftedBn.toArray('le', buf1.length)
+          const shiftedArr = shiftedBn.toArray('be', buf1.length)
           this.pushStack(shiftedArr)
           break
         }

--- a/src/script/__tests/Spend.test.ts
+++ b/src/script/__tests/Spend.test.ts
@@ -248,6 +248,24 @@ describe('Spend', () => {
     expect(valid).toBe(true)
   })
 
+  it('maintains endianness when shifting right', () => {
+    const spend = createSpendWithPushes(
+      'OP_1 OP_RSHIFT 0080 OP_EQUAL',
+      [[0x01, 0x00]]
+    )
+
+    expect(spend.validate()).toBe(true)
+  })
+
+  it('maintains endianness when shifting left', () => {
+    const spend = createSpendWithPushes(
+      'OP_1 OP_LSHIFT 0100 OP_EQUAL',
+      [[0x00, 0x80]]
+    )
+
+    expect(spend.validate()).toBe(true)
+  })
+
   it('Successfully validates an R-puzzle spend (HASH256)', async () => {
     const k = new PrivateKey(2)
     const c = new Curve()

--- a/src/transaction/__tests/Transaction.test.ts
+++ b/src/transaction/__tests/Transaction.test.ts
@@ -352,9 +352,9 @@ describe('Transaction', () => {
       expect(spendTx.outputs[1].satoshis).not.toBeDefined()
       await spendTx.fee()
       // Transaction size is 225 bytes for one-input two-output P2PKH.
-      // Default fee rate is 1 sat/kb = 0.225 sats (round up to 1).
-      // 4000 sats in - 1000 sats out - 3 sats fee = expected 2999 sats change.
-      expect(spendTx.outputs[1].satoshis).toEqual(2999)
+      // Default fee rate is 100 sat/kb = 22.5 sats (round up to 23).
+      // 4000 sats in - 1000 sats out - 23 sats fee = expected 2977 sats change.
+      expect(spendTx.outputs[1].satoshis).toEqual(2977)
     })
     it('Computes fees with a custom fee model', async () => {
       const privateKey = new PrivateKey(1)


### PR DESCRIPTION
## Description of Changes
- ensure `OP_LSHIFT` and `OP_RSHIFT` preserve the byte order of the item they operate on
- add regression tests proving the correct shift behavior and update the fee test expectation so the suite reflects the current default rate
- document the fix in the changelog and bump the package version for release

## Linked Issues / Tickets
- N/A

## Testing Procedure
- [x] I have added new unit tests
- [x] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f54e5ee0832eaf10e538a1597ae2)